### PR TITLE
Fix rendering of bootstrapped client

### DIFF
--- a/app/views/hello_world/index.html.erb
+++ b/app/views/hello_world/index.html.erb
@@ -1,3 +1,9 @@
+<h1>LaunchDarkly server-side bootstrap example</h1>
+<ul>
+    <li><code>normal client</code>: <span class="normal">initializing…</span></li>
+    <li><code>bootstraped client</code>: <span class="bootstrap">initializing…</span></li>
+</ul>
+
 <script src="https://app.launchdarkly.com/snippet/ldclient.min.js"></script>
 <script>
     var user = <%= raw @user %>;
@@ -25,8 +31,3 @@
         document.querySelector(selector).innerHTML = JSON.stringify(targetClient.allFlags(user), null, 2);
     }
 </script>
-<h1>LaunchDarkly server-side bootstrap example</h1>
-<ul>
-    <li><code>normal client</code>: <span class="normal">initializing…</span></li>
-    <li><code>bootstraped client</code>: <span class="bootstrap">initializing…</span></li>
-</ul>

--- a/app/views/hello_world/index.html.erb
+++ b/app/views/hello_world/index.html.erb
@@ -1,7 +1,7 @@
 <h1>LaunchDarkly server-side bootstrap example</h1>
 <ul>
     <li><code>normal client</code>: <span class="normal">initializing…</span></li>
-    <li><code>bootstraped client</code>: <span class="bootstrap">initializing…</span></li>
+    <li><code>bootstrapped client</code>: <span class="bootstrap">initializing…</span></li>
 </ul>
 
 <script src="https://app.launchdarkly.com/snippet/ldclient.min.js"></script>

--- a/app/views/hello_world/index.html.erb
+++ b/app/views/hello_world/index.html.erb
@@ -6,28 +6,28 @@
 
 <script src="https://app.launchdarkly.com/snippet/ldclient.min.js"></script>
 <script>
-    var user = <%= raw @user %>;
-    console.log(`Clients initialized`);
-    var client = LDClient.initialize('<%= @client_side_id %>', user);
-    var bootstrapClient = LDClient.initialize('<%= @client_side_id %>', user, {
-        bootstrap: <%= @all_flags_state %>
-    });
+  var user = <%= raw @user %>;
+  console.log(`Clients initialized`);
+  var client = LDClient.initialize('<%= @client_side_id %>', user);
+  var bootstrapClient = LDClient.initialize('<%= @client_side_id %>', user, {
+    bootstrap: <%= @all_flags_state %>
+  });
 
-        client.on('ready', handleUpdateNormalClient);
-        client.on('change', handleUpdateNormalClient);
-        bootstrapClient.on('ready', handleUpdateBootstrapClient);
-        bootstrapClient.on('change', handleUpdateBootstrapClient);
+  client.on('ready', handleUpdateNormalClient);
+  client.on('change', handleUpdateNormalClient);
+  bootstrapClient.on('ready', handleUpdateBootstrapClient);
+  bootstrapClient.on('change', handleUpdateBootstrapClient);
 
-        function handleUpdateNormalClient(){
-            console.log(`Normal SDK updated`);
-            render('.normal', client);
-        }
-        function handleUpdateBootstrapClient(){
-        console.log(`Bootstrapped SDK updated`);
-        render('.bootstrap', bootstrapClient);
-    }
+  function handleUpdateNormalClient() {
+    console.log(`Normal SDK updated`);
+    render('.normal', client);
+  }
+  function handleUpdateBootstrapClient() {
+    console.log(`Bootstrapped SDK updated`);
+    render('.bootstrap', bootstrapClient);
+  }
 
-    function render(selector, targetClient) {
-        document.querySelector(selector).innerHTML = JSON.stringify(targetClient.allFlags(user), null, 2);
-    }
+  function render(selector, targetClient) {
+    document.querySelector(selector).innerHTML = JSON.stringify(targetClient.allFlags(user), null, 2);
+  }
 </script>

--- a/app/views/hello_world/index.html.erb
+++ b/app/views/hello_world/index.html.erb
@@ -6,28 +6,30 @@
 
 <script src="https://app.launchdarkly.com/snippet/ldclient.min.js"></script>
 <script>
-  var user = <%= raw @user %>;
-  console.log(`Clients initialized`);
-  var client = LDClient.initialize('<%= @client_side_id %>', user);
-  var bootstrapClient = LDClient.initialize('<%= @client_side_id %>', user, {
-    bootstrap: <%= @all_flags_state %>
+  window.addEventListener('DOMContentLoaded', () => {
+    var user = <%= raw @user %>;
+    console.log(`Clients initialized`);
+    var client = LDClient.initialize('<%= @client_side_id %>', user);
+    var bootstrapClient = LDClient.initialize('<%= @client_side_id %>', user, {
+      bootstrap: <%= @all_flags_state %>
+    });
+
+    client.on('ready', handleUpdateNormalClient);
+    client.on('change', handleUpdateNormalClient);
+    bootstrapClient.on('ready', handleUpdateBootstrapClient);
+    bootstrapClient.on('change', handleUpdateBootstrapClient);
+
+    function handleUpdateNormalClient() {
+      console.log(`Normal SDK updated`);
+      render('.normal', client);
+    }
+    function handleUpdateBootstrapClient() {
+      console.log(`Bootstrapped SDK updated`);
+      render('.bootstrap', bootstrapClient);
+    }
+
+    function render(selector, targetClient) {
+      document.querySelector(selector).innerHTML = JSON.stringify(targetClient.allFlags(user), null, 2);
+    }
   });
-
-  client.on('ready', handleUpdateNormalClient);
-  client.on('change', handleUpdateNormalClient);
-  bootstrapClient.on('ready', handleUpdateBootstrapClient);
-  bootstrapClient.on('change', handleUpdateBootstrapClient);
-
-  function handleUpdateNormalClient() {
-    console.log(`Normal SDK updated`);
-    render('.normal', client);
-  }
-  function handleUpdateBootstrapClient() {
-    console.log(`Bootstrapped SDK updated`);
-    render('.bootstrap', bootstrapClient);
-  }
-
-  function render(selector, targetClient) {
-    document.querySelector(selector).innerHTML = JSON.stringify(targetClient.allFlags(user), null, 2);
-  }
 </script>


### PR DESCRIPTION
When loading the home page, the "bootstrapped client" block would always
show initializing despite that we are providing it with the correct
feature flag data on instantiation.

Because `<script>` tags block rendering of the DOM, and because a
bootstrapped client is immediately initialized, when we try to update
the text for the appropriate LI tag, we find that it doesn't exist in
the DOM yet.

This wasn't an issue for the standard JS client because it has to
actually connect to LD and fetch the flags asynchronously. This allowed
processing to continue and the DOM to finish rendering.

By moving JS execution to the bottom of the page, we can ensure the tags
are present as the time of initialization.